### PR TITLE
[1367] Discover Opaque TLS secrets

### DIFF
--- a/ibm/mas_devops/common_tasks/get_signed_ingress_cert.yml
+++ b/ibm/mas_devops/common_tasks/get_signed_ingress_cert.yml
@@ -122,8 +122,6 @@
         api_version: v1
         kind: Secret
         namespace: openshift-ingress
-        field_selectors:
-          - type=kubernetes.io/tls
       register: cluster_primary_secrets
 
     # This will lookup for cluster's ingress secret name that matches a given label


### PR DESCRIPTION
In ROSA with HCP, valid certificates are stored as type Opaque. This patch searches _all_ secrets in the openshift-ingress namespace for pattern matching.