### PR TITLE
Second attempt for efs-setup security group lookup

### DIFF
--- a/ibm/mas_devops/roles/ocp_efs/tasks/efs-setup.yml
+++ b/ibm/mas_devops/roles/ocp_efs/tasks/efs-setup.yml
@@ -30,13 +30,24 @@
 
 # 3. Get Security Group of the cluster
 # -----------------------------------------------------------------------------
-- name: "efs-setup : Get Security Group of the EC2 Istance"
+- name: "efs-setup : Get Security Group of the EC2 Instance"
   shell: aws ec2 describe-security-groups --filters Name=vpc-id,Values={{ vpcid }} Name=tag:Name,Values='*worker*' --query "SecurityGroups[*].{ID:GroupId}[0]"
   register: security_group
 
 - name: "efs-setup : Get Security Group Id from Output"
   set_fact:
     security_group_id: "{{ security_group.stdout | from_json | json_query(\"ID\") }}"
+
+- when:
+  - not security_group_id
+  block:
+    - name: "efs-setup : 2nd Attempt : Get Security Group of the EC2 Instance"
+      shell: aws ec2 describe-security-groups --filters Name=vpc-id,Values={{ vpcid }} Name=tag:api.openshift.com/id,Values='*' --query "SecurityGroups[*].{ID:GroupId}[0]"
+      register: security_group
+
+    - name: "efs-setup : 2nd Attempt: Get Security Group Id from Output"
+      set_fact:
+        security_group_id: "{{ security_group.stdout | from_json | json_query(\"ID\") }}"
 
 - name: "efs-setup : Debug Security Group Id"
   debug:


### PR DESCRIPTION
ROSA (HCP) does not include the "worker" filter in the Name tag for the security group. Instead, it assigns a unique tag.